### PR TITLE
reduce spatial range for averaged profile to match values elsewhere

### DIFF
--- a/generateAvgprofile.py
+++ b/generateAvgprofile.py
@@ -53,8 +53,8 @@ superMCParameters = {
     'nev'                           :   1000,
     'average_from_order'            :   2,
     'average_to_order'              :   2,
-    'maxx'                          :   15.0,
-    'maxy'                          :   15.0,
+    'maxx'                          :   13.0,
+    'maxy'                          :   13.0,
     'dx'                            :   0.1,
     'dy'                            :   0.1,
 }


### PR DESCRIPTION
in both VISHNew and superMC, default values correspond to 13fm, so should reduce
here to match - otherwise get grid truncated when exporting hydro to hdf5.